### PR TITLE
Fix Uncaught ReferenceError: regeneratorRuntime is not defined

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -2,7 +2,7 @@
   "presets": ["es2015", "stage-0", "react"],
   "env": {
     "development": {
-      "presets": ["react-hmre"]
+      "presets": ["react-hmre","env"]
     }
   }
 }

--- a/webpack.config.prod.js
+++ b/webpack.config.prod.js
@@ -12,6 +12,7 @@ const pkg = require('./package.json');
 module.exports = {
   devtool: 'source-map',
   entry: [
+    'babel-polyfill' ,
     './src/init/main',
   ],
   output: {

--- a/webpack.config.prod.js
+++ b/webpack.config.prod.js
@@ -1,6 +1,6 @@
 /* eslint-disable strict */
 'use strict';
-
+require("babel-polyfill");
 const APP_NAME = process.env.APP_NAME;
 
 const path = require('path');


### PR DESCRIPTION
If you try to host dist folder after build , with [serve ](https://www.npmjs.com/package/serve)
will encounter following Error:
_Uncaught ReferenceError: regeneratorRuntime is not defined_

> Serving builded content.
     serve -s dist -l 3000

This is my workaround to that.